### PR TITLE
Automatically add post year to e621 tags

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,7 +6,7 @@ const { performance } = require('perf_hooks');
 
 const apply_header = require('./dependencies/prepend-text.js');
 const info = {
-	base_version: 23,
+	base_version: 24,
 	authors: 'Meras',
 	updateURL: 'https://raw.githubusercontent.com/Sasquire/Idems-Sourcing-Suite/master/distribution/header.user.js',
 	downloadURL: 'https://raw.githubusercontent.com/Sasquire/Idems-Sourcing-Suite/master/distribution/main.user.js',

--- a/distribution/header.user.js
+++ b/distribution/header.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Idem's Sourcing Suite
 // @description  Adds a whole bunch of utilities, helpful for sourcing images
-// @version      1.00047
+// @version      1.00048
 // @author       Meras
 
 // @namespace    https://github.com/Sasquire/
@@ -12,7 +12,7 @@
 
 // @license      Unlicense
 
-//               Common v23
+//               Common v24
 // @noframes
 // @connect      e621.net
 // @grant        GM.addStyle

--- a/source/default_settings.js
+++ b/source/default_settings.js
@@ -4,6 +4,7 @@ module.exports = {
 	// Different parts of the on-site-utilities
 	on_site_hasher_enabled: true,
 	on_site_upload_enabled: true,
+	on_site_upload_add_year_tag: false,
 	on_site_commentary_enabled: true,
 
 	// Individual sites that control if the on-site-utilities become enabled.

--- a/source/plans/furaffinity/classic.js
+++ b/source/plans/furaffinity/classic.js
@@ -5,6 +5,7 @@ const get_info = async (full_url) => simple_site({
 	artist: document.querySelector('.information a'),
 	title: document.querySelector('.information h2'),
 	description: document.querySelector('.alt1[width="70%"]'),
+	year: new Date(document.querySelector('.popup_date').title).getFullYear().toString(),
 	full_url: full_url,
 	hashes: [
 		[full_to_thumb(full_url), 'thumb image']

--- a/source/plans/furaffinity/modern.js
+++ b/source/plans/furaffinity/modern.js
@@ -8,6 +8,7 @@ const get_info = async (full_url) => simple_site({
 	},
 	title: document.querySelector('.submission-title > h2'),
 	description: () => document.querySelector('.submission-description'),
+	year: document.querySelector('.popup_date').title.match(/\b\d{4}\b/),
 	full_url: full_url,
 	hashes: [
 		[full_to_thumb(full_url), 'thumb image']

--- a/source/plans/furrynetwork/main.js
+++ b/source/plans/furrynetwork/main.js
@@ -79,6 +79,7 @@ const get_info = async () => simple_site({
 	},
 	title: document.querySelector('.submission-description__title'),
 	description: document.querySelector('.submission-description__description__md'),
+	year: document.querySelector('.submission-description__created').title.match(/\b\d{4}\b/),
 	full_url: get_sources().full,
 	hashes: [
 		[get_sources().thumb, 'thumb image']

--- a/source/plans/inkbunny/main.js
+++ b/source/plans/inkbunny/main.js
@@ -149,7 +149,8 @@ function do_upload () {
 			generate_urls()[1],
 			get_artist().href
 		],
-		get_description()
+		get_description(),
+		document.querySelector('#submittime_exact').innerText.match(/\b\d{4}\b/)
 	);
 	const container = document.createElement('span');
 	container.appendChild(link);

--- a/source/plans/pixiv/main.js
+++ b/source/plans/pixiv/main.js
@@ -124,7 +124,8 @@ function do_upload () {
 				image.best_url,
 				gallery_url
 			],
-			get_description()
+			get_description(),
+			document.querySelector('[title="Posting date"]').textContent.match(/\b\d{4}\b/)
 		);
 
 		image.container.appendChild(button);

--- a/source/plans/settings/main.js
+++ b/source/plans/settings/main.js
@@ -32,6 +32,13 @@ function on_site_hasher_settings () {
 	});
 
 	settings.checkbox({
+		name: 'on-site-upload-add-year-tag',
+		key: 'on_site_upload_add_year_tag',
+		default: defaults.on_site_upload_add_year_tag,
+		description: 'Automatically guesses year-tags for posts. Enable only if you understand the risks.'
+	});
+
+	settings.checkbox({
 		name: 'on-site-commentary',
 		key: 'on_site_commentary_enabled',
 		default: defaults.on_site_commentary_enabled,

--- a/source/plans/sofurry/main.js
+++ b/source/plans/sofurry/main.js
@@ -23,6 +23,7 @@ const get_info = async () => simple_site({
 	},
 	title: document.getElementById('sfContentTitle'),
 	description: document.getElementById('sfContentBody'),
+	year: document.querySelectorAll('.section-content')[4].innerText.split('\n')[0].match(/\b\d{4}\b/),
 	full_url: get_urls()[0][0],
 	hashes: get_urls().slice(1),
 	css: `

--- a/source/plans/twitter/main.js
+++ b/source/plans/twitter/main.js
@@ -111,10 +111,14 @@ async function build_info () {
 	// it is empty is a lot better
 	const description = document.querySelector('[data-testid=tweet] ~ [dir=auto] > span');
 	const sources = await get_sources();
+	// TODO: Clean this query up
+	const date = await document.body.arrive('#layers > div:nth-child(2) > div > div > div > div > div > div.css-1dbjc4n.r-1awozwy.r-18u37iz.r-1pi2tsx.r-1777fci.r-1xcajam.r-ipm5af.r-g6jmlv > div.css-1dbjc4n.r-17gur6a.r-1wbh5a2.r-1pi2tsx.r-htvplk.r-1udh08x.r-13qz1uu > div > div.css-1dbjc4n.r-yfoy6g.r-18bvks7.r-1ljd8xs.r-1phboty.r-1dqxon3.r-1hycxz > div > section > div > div > div:nth-child(1) > div > div > article > div > div > div > div:nth-child(3) > div.css-1dbjc4n.r-1r5su4o > div > div.css-901oao.r-111h2gw.r-1qd0xha.r-a023e6.r-16dba41.r-rjixqe.r-1b7u577.r-bcqeeo.r-qvutc0 > a:nth-child(1) > span');
+	const year = date.textContent.slice(-4);
 
 	return get_info({
 		artist: artist,
 		description: description,
+		year: year,
 		sources: sources
 	});
 }
@@ -123,6 +127,7 @@ const get_info = async (pre_found) => simple_site({
 	artist: pre_found.artist,
 	title: null, // No titles on twitter
 	description: pre_found.description,
+	year: pre_found.year,
 	full_url: pre_found.sources[0][0],
 	full_url_name: 'orig',
 	hashes: pre_found.sources.slice(1),

--- a/source/plans/weasyl/main.js
+++ b/source/plans/weasyl/main.js
@@ -4,6 +4,7 @@ const get_info = async () => simple_site({
 	artist: document.querySelector('#db-user > .username'),
 	title: document.querySelector('#detail-bar-title'),
 	description: document.querySelector('#detail-description > .formatted-content'),
+	year: document.querySelector('.date').innerText.match(/\b\d{4}\b/),
 	full_url: document.querySelector('#detail-art > a').href,
 	hashes: [
 		[document.querySelector('#detail-art > a > img').src, 'thumb image']

--- a/source/utils/node_to_dtext.js
+++ b/source/utils/node_to_dtext.js
@@ -74,7 +74,7 @@ function node_to_plain_text (entry) {
 	} else if (typeof entry === 'string') {
 		return entry;
 	}
-console.log(entry)
+
 	switch (entry.nodeName) {
 		case '#comment':
 		case 'IMG': return ''; // Images get destroyed :(

--- a/source/utils/simple_site.js
+++ b/source/utils/simple_site.js
@@ -28,9 +28,23 @@ async function build_simple (options) {
 		options.artist.href
 	];
 
-	const tags = [
-		options.year
+	const setting_value_pairs = [
+		['on_site_upload_add_year_tag', options.year]
 	];
+
+	const tags = [];
+	for (const [setting_name, result_value] of setting_value_pairs) {
+		if (result_value === null) {
+			continue;
+		} else if (typeof result_value !== 'string') {
+			throw new Error(`For setting ${setting_name}, tried to add a non-string value`);
+		} else {
+			const should_include = await get_value(setting_name);
+			if (should_include === true) {
+				tags.push(result_value);
+			}
+		}
+	}
 
 	let commentary_span = null;
 	const on_site_commentary_enabled = await get_value('on_site_commentary_enabled');

--- a/source/utils/simple_site.js
+++ b/source/utils/simple_site.js
@@ -9,6 +9,7 @@ async function build_simple (options) {
 	// artist
 	// title
 	// description
+	// year
 	// full_url
 	// full_url_name
 	// hashes
@@ -27,6 +28,10 @@ async function build_simple (options) {
 		options.artist.href
 	];
 
+	const tags = [
+		options.year
+	];
+
 	let commentary_span = null;
 	const on_site_commentary_enabled = await get_value('on_site_commentary_enabled');
 	if (on_site_commentary_enabled === true) {
@@ -38,7 +43,7 @@ async function build_simple (options) {
 	const on_site_upload_enabled = await get_value('on_site_upload_enabled');
 	if (on_site_upload_enabled === true) {
 		upload_span = document.createElement('span');
-		const button = upload_button(options.full_url, sources, commentary);
+		const button = upload_button(options.full_url, sources, commentary, tags);
 		upload_span.appendChild(button);
 	}
 


### PR DESCRIPTION
Updated `simple_sites.js` to support a `year` option.

Currently supported sites:

- [x] Twitter
- [x] FurAffinity
- [x] Pixiv
- [x] SoFurry
- [x] FurryNetwork
- [x] Weasyl
- [x] Inkbunny
- [ ] DeviantArt

I'll add support for all sites soon since it's dead simple to do.
Also, I haven't updated `main.user.js` in this PR, but I could add it, if wanted.